### PR TITLE
chore(workflows): wire reusable-* callers to portfolio-app token cascade

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -19,9 +19,12 @@ on:
 
 jobs:
   automerge:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-automerge.yaml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-automerge.yaml@v1.1.18
+    with:
+      app-id: ${{ vars.PORTFOLIO_APP_ID }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+      app-private-key: ${{ secrets.PORTFOLIO_APP_PRIVATE_KEY }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/build-static-tests.yaml
+++ b/.github/workflows/build-static-tests.yaml
@@ -3,16 +3,16 @@ on:
 
 jobs:
   static:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@v1.1.18
 
   security:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-trivy.yaml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-trivy.yaml@v1.1.18
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
 
   chain-bench:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-chain-bench.yaml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-chain-bench.yaml@v1.1.18
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-cd-deliver-docs.yml
+++ b/.github/workflows/release-cd-deliver-docs.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   publish_docs:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-mkdocs.yaml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-mkdocs.yaml@v1.1.18
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
     permissions:

--- a/.github/workflows/release-cd-refresh-master.yml
+++ b/.github/workflows/release-cd-refresh-master.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   refresh_presentation_branch:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-release-cd-refresh-master.yml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-cd-refresh-master.yml@v1.1.18
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
     with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   update_release_draft:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-release-drafter.yml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-drafter.yml@v1.1.18
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
     permissions:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,28 @@
+name: Release Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Draft tag to publish. Must match an existing release-drafter draft."
+        required: true
+        type: string
+      dry_run:
+        description: "Validate only; do not flip draft -> published."
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@v1.1.18
+    with:
+      tag: ${{ inputs.tag }}
+      dry_run: ${{ inputs.dry_run }}
+      app-id: ${{ vars.PORTFOLIO_APP_ID }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+      app-private-key: ${{ secrets.PORTFOLIO_APP_PRIVATE_KEY }}

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -8,4 +8,4 @@ permissions:
 
 jobs:
   spelling:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-spelling-vale.yaml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-spelling-vale.yaml@v1.1.18


### PR DESCRIPTION
## Summary

Bring all reusable-workflow callers under \`.github/workflows/\` to
\`gh-plumbing@v1.1.18\` and onto the App-installation-token cascade
(issue [#330](https://github.com/nolte/gh-plumbing/issues/330)).

The \`automerge.yaml\` caller used to track the moving \`develop\` branch
of \`gh-plumbing\`; this PR pins it to the v1.1.18 release in line with
every other caller in the repo.

## Changes

- \`automerge.yaml\`: pin \`develop → v1.1.18\`; pass
  \`app-id: \${{ vars.PORTFOLIO_APP_ID }}\` and
  \`secrets.app-private-key: \${{ secrets.PORTFOLIO_APP_PRIVATE_KEY }}\`.
- \`build-static-tests.yaml\`: pin \`v1.1.12 → v1.1.18\` on all three
  reusable calls.
- \`spelling.yaml\`, \`release-drafter.yml\`,
  \`release-cd-refresh-master.yml\`, \`release-cd-deliver-docs.yml\`: pin
  \`v1.1.12 → v1.1.18\`.
- \`release-publish.yml\`: **new file**. The repo has no claude-plugin /
  python / node / HA layout, so the reusable falls into the
  \`source: none\` branch and skips version-bearing-file alignment.

## Linked issues

\`nolte/gh-plumbing#330\` — App-installation-token cascade.

## Risk / rollout notes

Pure CI wiring. App credentials are already in place on this repo via
\`terraform/portfolio-app/\` in \`nolte/terraform-github-bootstrap\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)