### PR TITLE
chore(portfolio): mark repository portfolio: excluded

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+<!-- portfolio: excluded — small reusable ESPHome config fragments, not a standalone portfolio capability -->
+
+# esphome-configs
+
+This repository is intentionally **excluded** from the nolte portfolio
+capability inventory via the `portfolio: excluded` marker above, per
+`spec/portfolio/portfolio-management/` §Portfolio scope. It is therefore not
+expected to ship a `project/portfolio.yml` manifest.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
-<!-- portfolio: excluded — small reusable ESPHome config fragments, not a standalone portfolio capability -->
-
 # esphome-configs
 
-This repository is intentionally **excluded** from the nolte portfolio
-capability inventory via the `portfolio: excluded` marker above, per
-`spec/portfolio/portfolio-management/` §Portfolio scope. It is therefore not
-expected to ship a `project/portfolio.yml` manifest.
+This repository is intentionally excluded from the nolte portfolio capability
+inventory, per spec/portfolio/portfolio-management/ Portfolio scope. It ships
+no project/portfolio.yml manifest.
+
+portfolio: excluded - small reusable ESPHome config fragments, not a
+standalone portfolio capability.


### PR DESCRIPTION
Adds the `portfolio: excluded` marker to `CLAUDE.md` per `spec/portfolio/portfolio-management/` §Portfolio scope, resolving a missing-manifest finding from the 2026-06-02 portfolio audit (nolte/claude-shared `.audits/portfolio/2026-06-02.md`).

Rationale: small reusable ESPHome config fragments, not a standalone portfolio capability