### PR TITLE
fix(ci): point release-cd-refresh-master at master

### DIFF
--- a/.github/workflows/release-cd-refresh-master.yml
+++ b/.github/workflows/release-cd-refresh-master.yml
@@ -8,6 +8,6 @@ jobs:
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
     with:
-      target_branch: main
+      target_branch: master
     permissions:
       contents: write


### PR DESCRIPTION
### Description

Fixes the `release-cd-refresh-master` workflow that failed on the `v0.1.4` publish.

### Changes

- `release-cd-refresh-master.yml`: `target_branch: main` → `target_branch: master`

### Context

This repository's presentation branch is `master` (the default branch is `develop`); there is no
`main` branch. The post-publish refresh therefore tried to merge the release tag into a
non-existent base and failed with `404 - Base does not exist`. The `v0.1.4` release published
successfully, but `master` was not refreshed automatically (it has since been fast-forwarded
manually to the v0.1.4 state).

### Testing

- Verified the remote branch set contains `master` but no `main`
  (`develop`, `gh-pages`, `master`, `renovate/all`).

### Risk / rollout notes

CI-only change. Effect is visible on the next release publish, when the presentation branch refresh
should succeed instead of erroring.
